### PR TITLE
refactor: 가계부 상세 아이템 조회 페이지 

### DIFF
--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -127,7 +127,7 @@ export const router = createBrowserRouter([
         ]
       },
       {
-        path: '/accountBook/calendar/detail/:date/:id',
+        path: '/accountBook/:groupId/calendar/:id',
         Component: DetailAccountItemPage,
         handle: {
           hideNav: true

--- a/src/features/calendar/ui/overlay/DateListOverlay.tsx
+++ b/src/features/calendar/ui/overlay/DateListOverlay.tsx
@@ -5,7 +5,6 @@ import { ListHeader } from './ListHeader'
 import type { AccountItem } from '@/features/accountItem/index'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useNavigate } from 'react-router'
-import dayjs from 'dayjs'
 
 interface Props {
   isOpen: boolean

--- a/src/features/calendar/ui/overlay/DateListOverlay.tsx
+++ b/src/features/calendar/ui/overlay/DateListOverlay.tsx
@@ -9,11 +9,17 @@ import dayjs from 'dayjs'
 
 interface Props {
   isOpen: boolean
+  groupId: string
   setIsOpen: (isOpen: boolean) => void
   events: AccountItem[]
 }
 
-export const DateListOverlay = ({ isOpen, setIsOpen, events }: Props) => {
+export const DateListOverlay = ({
+  isOpen,
+  setIsOpen,
+  events,
+  groupId
+}: Props) => {
   const ref = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const [entering, setEntering] = useState(false)
@@ -198,9 +204,7 @@ export const DateListOverlay = ({ isOpen, setIsOpen, events }: Props) => {
                     amount={Number(item.amount)}
                     type={item.type}
                     gotoDetail={() =>
-                      navigate(
-                        `/accountBook/calendar/detail/${dayjs(item.date).format('YYYY-MM-DD')}/${item.id}`
-                      )
+                      navigate(`/accountBook/${groupId}/calendar/${item.id}`)
                     }
                   />
                 ))}

--- a/src/features/detail/service/deleteComment.ts
+++ b/src/features/detail/service/deleteComment.ts
@@ -5,7 +5,5 @@ export async function deleteComment(deletedId: string) {
 
   if (error) {
     alert(`삭제 실패: ${error.message}`)
-  } else {
-    alert('삭제 성공!')
   }
 }

--- a/src/features/detail/ui/DetailContents.tsx
+++ b/src/features/detail/ui/DetailContents.tsx
@@ -63,6 +63,7 @@ export function DetailContents({
             <p>{writer}</p>
             {isMine && (
               <ToggleMoreButton
+                label="일별 가계부"
                 deletedId={item_id}
                 isOpen={isArticleToggleOn}
                 onChangeToggle={onChangeArticleToggle}

--- a/src/features/detail/ui/DetailContents.tsx
+++ b/src/features/detail/ui/DetailContents.tsx
@@ -9,7 +9,8 @@ interface Props {
   isArticleToggleOn: boolean
   receipt_url?: string
   payment_methods?: string
-  user_id: string
+  writer: string
+  isMine: boolean
   memo?: string
   item_id: string
   reactions: Reactions[]
@@ -28,15 +29,15 @@ interface Props {
 export function DetailContents({
   isArticleToggleOn,
   item_id,
+  isMine,
   payment_methods,
-  user_id,
+  writer,
   receipt_url,
   memo,
   reactions,
   onChangeArticleToggle,
   handleReactions
 }: Props) {
-
   const navigate = useNavigate()
 
   const handleDelete = async (id: string) => {
@@ -59,14 +60,16 @@ export function DetailContents({
           )}>
           {payment_methods && <p>결제수단: {payment_methods}</p>}
           <div className="flex absolute right-0">
-            <p>{user_id}</p>
-            <ToggleMoreButton
-              deletedId={item_id}
-              isOpen={isArticleToggleOn}
-              onChangeToggle={onChangeArticleToggle}
-              onEdit={() => navigate(`/accountBook/item/${item_id}/edit`)}
-              onDelete={handleDelete}
-            />
+            <p>{writer}</p>
+            {isMine && (
+              <ToggleMoreButton
+                deletedId={item_id}
+                isOpen={isArticleToggleOn}
+                onChangeToggle={onChangeArticleToggle}
+                onEdit={() => navigate(`/accountBook/item/${item_id}/edit`)}
+                onDelete={handleDelete}
+              />
+            )}
           </div>
         </div>
         {receipt_url && (

--- a/src/features/detail/ui/DetailContents.tsx
+++ b/src/features/detail/ui/DetailContents.tsx
@@ -4,6 +4,7 @@ import ReactionButtonContainer from './ReactionButtonContainer'
 import ToggleMoreButton from './ToggleMoreButton'
 import { useNavigate } from 'react-router'
 import { deleteAccountItem } from '@/pages/item/delete/deleteAccountItem'
+import { useEffect, useRef } from 'react'
 
 interface Props {
   isArticleToggleOn: boolean
@@ -39,6 +40,21 @@ export function DetailContents({
   handleReactions
 }: Props) {
   const navigate = useNavigate()
+  const toggleRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        isArticleToggleOn &&
+        toggleRef.current &&
+        !toggleRef.current.contains(e.target as Node)
+      ) {
+        onChangeArticleToggle()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isArticleToggleOn, onChangeArticleToggle])
 
   const handleDelete = async (id: string) => {
     try {
@@ -62,14 +78,16 @@ export function DetailContents({
           <div className="flex absolute right-0">
             <p>{writer}</p>
             {isMine && (
-              <ToggleMoreButton
-                label="일별 가계부"
-                deletedId={item_id}
-                isOpen={isArticleToggleOn}
-                onChangeToggle={onChangeArticleToggle}
-                onEdit={() => navigate(`/accountBook/item/${item_id}/edit`)}
-                onDelete={handleDelete}
-              />
+              <div ref={toggleRef}>
+                <ToggleMoreButton
+                  label="일별 가계부"
+                  deletedId={item_id}
+                  isOpen={isArticleToggleOn}
+                  onChangeToggle={onChangeArticleToggle}
+                  onEdit={() => navigate(`/accountBook/item/${item_id}/edit`)}
+                  onDelete={handleDelete}
+                />
+              </div>
             )}
           </div>
         </div>

--- a/src/features/detail/ui/ReactionButtonContainer.tsx
+++ b/src/features/detail/ui/ReactionButtonContainer.tsx
@@ -36,11 +36,12 @@ function ReactionButtonContainer({
   const handleReactions = (kind: string) => {
     onChangeReaction({ itemId: item_id, kind, userId: userId! })
   }
+
   useEffect(() => {
     const { kind } = getUserReaction(reactions, userId)
     if (kind === 'dislike') setIsDislikeClicked(true)
     if (kind === 'like') setIsLikeActive(true)
-  }, [])
+  }, [reactions])
 
   return (
     <div className="flex gap-7">

--- a/src/features/detail/ui/ToggleMoreButton.tsx
+++ b/src/features/detail/ui/ToggleMoreButton.tsx
@@ -45,20 +45,20 @@ function ToggleMoreButton({
           alt=""
         />
       </div>
-        <ConfirmModal
-          open={isDelete}
-          title="가계부 삭제"
-          lines={['삭제 후에는 복구가 어려워요.', '그래도 진행하시겠습니까?']}
-          onCancel={() => setIsDelete(false)}
-          onConfirm={async () => {
-            if (onDelete) {
-              await onDelete(deletedId)
-            }
-            setIsDelete(false)
-          }}
-          cancelText="취소"
-          confirmText="확인"
-        />
+      <ConfirmModal
+        open={isDelete}
+        title="가계부 삭제"
+        lines={['삭제 후에는 복구가 어려워요.', '그래도 진행하시겠습니까?']}
+        onCancel={() => setIsDelete(false)}
+        onConfirm={async () => {
+          if (onDelete) {
+            await onDelete(deletedId)
+          }
+          setIsDelete(false)
+        }}
+        cancelText="취소"
+        confirmText="확인"
+      />
     </>
   )
 }

--- a/src/features/detail/ui/ToggleMoreButton.tsx
+++ b/src/features/detail/ui/ToggleMoreButton.tsx
@@ -3,6 +3,7 @@ import ConfirmModal from '@/shared/components/modal/ConfirmModal'
 import { useState } from 'react'
 
 interface Props {
+  label: string
   isOpen: boolean
   deletedId: string
   onChangeToggle: () => void
@@ -10,6 +11,7 @@ interface Props {
   onDelete?: (deletedId: string) => Promise<void>
 }
 function ToggleMoreButton({
+  label,
   isOpen,
   deletedId,
   onEdit,
@@ -47,7 +49,7 @@ function ToggleMoreButton({
       </div>
       <ConfirmModal
         open={isDelete}
-        title="가계부 삭제"
+        title={`${label} 삭제`}
         lines={['삭제 후에는 복구가 어려워요.', '그래도 진행하시겠습니까?']}
         onCancel={() => setIsDelete(false)}
         onConfirm={async () => {

--- a/src/features/detail/ui/ToggleMoreButton.tsx
+++ b/src/features/detail/ui/ToggleMoreButton.tsx
@@ -19,15 +19,12 @@ function ToggleMoreButton({
   onChangeToggle
 }: Props) {
   const [isDelete, setIsDelete] = useState(false)
-  const handleToggle = () => {
-    onChangeToggle()
-  }
 
   return (
     <>
       <div
         className="relative cursor-pointer"
-        onClick={handleToggle}>
+        onClick={onChangeToggle}>
         {isOpen && (
           <div className="absolute right-0 top-5 w-25  shadow-md rounded-md bg-white text-center border-0.5 cursor-pointer z-10">
             <button

--- a/src/features/detail/ui/comment/Comment.tsx
+++ b/src/features/detail/ui/comment/Comment.tsx
@@ -51,6 +51,7 @@ function Comment({
         <div className="w-5">
           {isMine && (
             <ToggleMoreButton
+              label="댓글"
               deletedId={commentId}
               onEdit={() => setIsEdit(true)}
               onDelete={onDelete}

--- a/src/features/detail/ui/comment/Comment.tsx
+++ b/src/features/detail/ui/comment/Comment.tsx
@@ -19,7 +19,6 @@ function Comment({
   isMine,
   created_at,
   commentId,
-
   userId,
   onEdit,
   onDelete

--- a/src/features/detail/ui/comment/Comment.tsx
+++ b/src/features/detail/ui/comment/Comment.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import ToggleMoreButton from '../ToggleMoreButton'
 
 interface Props {
@@ -28,6 +28,21 @@ function Comment({
 }: Props) {
   const [isEdit, setIsEdit] = useState(false)
   const [text, setText] = useState(content)
+  const toggleRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        isOpen &&
+        toggleRef.current &&
+        !toggleRef.current.contains(e.target as Node)
+      ) {
+        onToggle()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen, onToggle])
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
@@ -50,14 +65,16 @@ function Comment({
         <span className="text-size-sm text-neutral-DEFAULT">{created_at}</span>
         <div className="w-5">
           {isMine && (
-            <ToggleMoreButton
-              label="댓글"
-              deletedId={commentId}
-              onEdit={() => setIsEdit(true)}
-              onDelete={onDelete}
-              isOpen={isOpen}
-              onChangeToggle={onToggle}
-            />
+            <div ref={toggleRef}>
+              <ToggleMoreButton
+                label="댓글"
+                deletedId={commentId}
+                onEdit={() => setIsEdit(true)}
+                onDelete={onDelete}
+                isOpen={isOpen}
+                onChangeToggle={onToggle}
+              />
+            </div>
           )}
         </div>
       </div>
@@ -74,7 +91,7 @@ function Comment({
           <div className="flex justify-end ">
             <button
               type="button"
-              className=" px-2.5 py-0.5 bg-neutral-light"
+              className=" px-2.5 py-0.5 rounded-md bg-neutral-light hover:bg-neutral-DEFAULT"
               onClick={onSubmit}>
               수정
             </button>

--- a/src/features/detail/ui/comment/Comment.tsx
+++ b/src/features/detail/ui/comment/Comment.tsx
@@ -5,10 +5,11 @@ interface Props {
   commentId: string
   content: string
   userId: string
-
   writer: string
   isMine: boolean
   created_at: string
+  isOpen: boolean
+  onToggle: () => void
   onDelete: (itemId: string) => Promise<void>
   onEdit: (commentId: string, userId: string, content: string) => Promise<void>
 }
@@ -20,15 +21,13 @@ function Comment({
   created_at,
   commentId,
   userId,
+  isOpen,
+  onToggle,
   onEdit,
   onDelete
 }: Props) {
-  const [isToggleOn, setIsToggleOn] = useState(false)
   const [isEdit, setIsEdit] = useState(false)
   const [text, setText] = useState(content)
-  const onChangeToggle = () => {
-    setIsToggleOn(!isToggleOn)
-  }
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
@@ -55,8 +54,8 @@ function Comment({
               deletedId={commentId}
               onEdit={() => setIsEdit(true)}
               onDelete={onDelete}
-              isOpen={isToggleOn}
-              onChangeToggle={onChangeToggle}
+              isOpen={isOpen}
+              onChangeToggle={onToggle}
             />
           )}
         </div>

--- a/src/features/detail/ui/comment/Comment.tsx
+++ b/src/features/detail/ui/comment/Comment.tsx
@@ -33,11 +33,9 @@ function Comment({
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
-      // 줄바꿈 허용
-      if (e.shiftKey) {
-        return
-      }
+      if (e.shiftKey) return
       e.preventDefault()
+      e.stopPropagation()
       onSubmit()
     }
   }

--- a/src/features/detail/ui/comment/CommentContainer.tsx
+++ b/src/features/detail/ui/comment/CommentContainer.tsx
@@ -6,6 +6,7 @@ import {
   getCreateFormatDate,
   sortByCreatedAtDesc
 } from '../../utils/dateFormat'
+import { useState } from 'react'
 
 interface Props {
   commentData?: Comments[]
@@ -30,6 +31,8 @@ export function CommentContainer({
   handleCommentEdit,
   onDelete
 }: Props) {
+  const [openCommentId, setOpenCommentId] = useState<string | null>(null)
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault()
@@ -60,15 +63,19 @@ export function CommentContainer({
       {commentData &&
         sortByCreatedAtDesc(commentData).map(item => (
           <Comment
+            key={item.id}
             userId={userId}
             commentId={item.id}
             onDelete={onDelete}
             onEdit={handleCommentEdit}
             isMine={item.user_id === userId}
-            key={item.id}
             created_at={getCreateFormatDate(item.created_at)}
             content={item.content}
             writer={item.users.nickname}
+            isOpen={openCommentId === item.id}
+            onToggle={() =>
+              setOpenCommentId(prev => (prev === item.id ? null : item.id))
+            }
           />
         ))}
     </div>

--- a/src/features/detail/ui/comment/CommentContainer.tsx
+++ b/src/features/detail/ui/comment/CommentContainer.tsx
@@ -2,7 +2,6 @@ import Input from '@/shared/components/form/Input'
 import Comment from './Comment'
 import type { Comments } from '../../model/responseBody'
 import sendIcon from '@/shared/assets/icons/send.svg'
-import { useUserStore } from '@/shared/stores/useUserStore'
 import {
   getCreateFormatDate,
   sortByCreatedAtDesc
@@ -11,6 +10,7 @@ import {
 interface Props {
   commentData?: Comments[]
   itemId: string
+  userId: string
   commentRef: React.RefObject<HTMLInputElement | null>
   handleComments: (item_id: string, user_id: string) => Promise<void>
   onDelete: (itemId: string) => Promise<void>
@@ -25,12 +25,11 @@ export function CommentContainer({
   commentData,
   commentRef,
   itemId,
+  userId,
   handleComments,
   handleCommentEdit,
   onDelete
 }: Props) {
-  const userId = useUserStore.getState().user!.id
-
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault()

--- a/src/features/detail/ui/comment/CommentContainer.tsx
+++ b/src/features/detail/ui/comment/CommentContainer.tsx
@@ -34,10 +34,10 @@ export function CommentContainer({
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault()
+      e.stopPropagation()
       handleComments(itemId, userId)
     }
   }
-
   const onSubmit = () => {
     handleComments(itemId, userId)
   }

--- a/src/features/detail/utils/getReaction.ts
+++ b/src/features/detail/utils/getReaction.ts
@@ -3,9 +3,9 @@ import type { Reactions } from '../model/responseBody'
 // 좋아요, 싫어요 버튼 수 카운트
 export function getReactionCount(reactions: Reactions[]) {
   if (!reactions) return { dislike: 0, like: 0 }
-  const dislike = reactions.filter(item => item.kind === 'dislike').length
-  const like = reactions.filter(item => item.kind === 'like').length
-  return { dislike, like }
+  const dislikeCount = reactions.filter(item => item.kind === 'dislike').length
+  const likeCount = reactions.filter(item => item.kind === 'like').length
+  return { dislikeCount, likeCount }
 }
 
 // 유저가 클릭한 버튼 반환

--- a/src/features/detail/utils/getReaction.ts
+++ b/src/features/detail/utils/getReaction.ts
@@ -10,7 +10,11 @@ export function getReactionCount(reactions: Reactions[]) {
 
 // 유저가 클릭한 버튼 반환
 export function getUserReaction(reactions: Reactions[], userId: string) {
-  if (reactions.length === 0) return { kind: 'none' }
   const userReaction = reactions.filter(item => item.user_id === userId)
+
+  if (!userReaction || reactions.length === 0) {
+    return { kind: 'none' }
+  }
+
   return userReaction[0]
 }

--- a/src/pages/calendar/ui/page.tsx
+++ b/src/pages/calendar/ui/page.tsx
@@ -126,6 +126,7 @@ export const CalendarPage = () => {
           handleDateClick={handleDateClick}
         />
         <DateListOverlay
+          groupId={storageGroup}
           isOpen={isOpen}
           setIsOpen={setIsOpen}
           events={calendarEventsByDate}

--- a/src/pages/detail/DetailAccountItemPage.tsx
+++ b/src/pages/detail/DetailAccountItemPage.tsx
@@ -21,8 +21,7 @@ import { Fragment, useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 
 function DetailAccountItemPage() {
-  const { date, id } = useParams()
-  const title = date ? dayjs(date).format('M월 D일 ddd') : ''
+  const { id } = useParams()
   const [isArticleToggleOn, setIsArticleToggleOn] = useState(false)
   const [detailItemData, setDetailItemData] = useState<
     DetailAccountItem[] | null
@@ -30,6 +29,8 @@ function DetailAccountItemPage() {
   const [commentsData, setCommentsData] = useState<Comments[] | null>(null)
   const commentRef = useRef<HTMLInputElement>(null)
   const itemId = detailItemData?.[0]?.id
+  const itemCreatedAt = detailItemData?.[0]?.date
+  const title = itemCreatedAt ? dayjs(itemCreatedAt).format('M월 D일 ddd') : ''
 
   const onOpenArticleToggle = () => {
     setIsArticleToggleOn(!isArticleToggleOn)
@@ -48,7 +49,6 @@ function DetailAccountItemPage() {
       await insertReaction(itemId, userId, kind)
       fetchDetailData(id!)
     } catch (error) {
-      console.log('리액션 에러', error)
       alert('리액션 중 오류가 발생했습니다.')
     }
   }

--- a/src/pages/detail/DetailAccountItemPage.tsx
+++ b/src/pages/detail/DetailAccountItemPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/features/detail/service/fetchDetailData'
 import { updateComment } from '@/features/detail/service/updateComment'
 import Header from '@/shared/components/header/Header'
+import { useUserStore } from '@/shared/stores/useUserStore'
 import dayjs from 'dayjs'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
@@ -32,6 +33,7 @@ function DetailAccountItemPage() {
   const itemCreatedAt = detailItemData?.[0]?.date
   const title = itemCreatedAt ? dayjs(itemCreatedAt).format('M월 D일 ddd') : ''
   const navigate = useNavigate()
+  const userId = useUserStore.getState().user!.id
 
   const onOpenArticleToggle = () => {
     setIsArticleToggleOn(!isArticleToggleOn)
@@ -158,8 +160,9 @@ function DetailAccountItemPage() {
                 type={item.type}
               />
               <DetailContents
+                isMine={item.users.id === userId}
                 item_id={String(item.id)}
-                user_id={item.users.nickname}
+                writer={item.users.nickname}
                 receipt_url={item.receipt_url!}
                 payment_methods={item.payment_methods?.type}
                 memo={item.memo ?? ''}
@@ -172,6 +175,7 @@ function DetailAccountItemPage() {
           ))}
 
         <CommentContainer
+          userId={userId}
           onDelete={handleCommentDelete}
           itemId={String(itemId)}
           handleComments={handleComments}

--- a/src/pages/detail/DetailAccountItemPage.tsx
+++ b/src/pages/detail/DetailAccountItemPage.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/features/detail/service/fetchDetailData'
 import { updateComment } from '@/features/detail/service/updateComment'
 import Header from '@/shared/components/header/Header'
+import { useSnackbarStore } from '@/shared/stores/useSnackbarStore'
 import { useUserStore } from '@/shared/stores/useUserStore'
 import dayjs from 'dayjs'
 import { Fragment, useEffect, useRef, useState } from 'react'
@@ -34,6 +35,7 @@ function DetailAccountItemPage() {
   const title = itemCreatedAt ? dayjs(itemCreatedAt).format('M월 D일 ddd') : ''
   const navigate = useNavigate()
   const userId = useUserStore.getState().user!.id
+  const showSnackbar = useSnackbarStore(state => state.showSnackbar)
 
   const onOpenArticleToggle = () => {
     setIsArticleToggleOn(!isArticleToggleOn)
@@ -52,13 +54,20 @@ function DetailAccountItemPage() {
       await insertReaction(itemId, userId, kind)
       fetchDetailData(id!)
     } catch (error) {
-      alert('리액션 중 오류가 발생했습니다.')
+      console.error('리액트 업로드  에러', error)
+      showSnackbar({
+        text: '리액션 중 오류가 발생했습니다',
+        type: 'error'
+      })
     }
   }
 
   const handleComments = async (item_id: string, user_id: string) => {
     if (commentRef.current?.value.trim() === '') {
-      return alert('공백은 입력할 수 없습니다!')
+      return showSnackbar({
+        text: '공백은 입력할 수 없습니다',
+        type: 'error'
+      })
     }
     try {
       const request = {
@@ -72,9 +81,11 @@ function DetailAccountItemPage() {
         commentRef.current.value = ''
       }
     } catch (error) {
-      console.log(' 댓글 업로드  에러', error)
-
-      alert('댓글 업로드 중 오류가 발생했습니다.')
+      console.error(' 댓글 업로드  에러', error)
+      showSnackbar({
+        text: '댓글 업로드 중 오류가 발생했습니다',
+        type: 'error'
+      })
     }
   }
 
@@ -84,7 +95,10 @@ function DetailAccountItemPage() {
     content: string
   ) => {
     if (!commentId || !userId)
-      return alert('댓글 수정 중, 필요한 정보가 부족합니다')
+      showSnackbar({
+        text: '댓글을 수정할 수 없습니다',
+        type: 'error'
+      })
     try {
       const request = {
         id: commentId,
@@ -95,9 +109,12 @@ function DetailAccountItemPage() {
       await updateComment(request!)
       fetchCommentData(id!)
     } catch (error) {
-      console.log('댓글 수정 에러', error)
+      console.error('댓글 수정 에러', error)
 
-      alert('댓글 수정 중 오류가 발생했습니다.')
+      showSnackbar({
+        text: '댓글 수정 중 오류가 발생했습니다',
+        type: 'error'
+      })
     }
   }
 
@@ -105,9 +122,16 @@ function DetailAccountItemPage() {
     try {
       await deleteComment(deletedId)
       fetchCommentData(id!)
+      showSnackbar({
+        text: '댓글 삭제 완료',
+        type: 'success'
+      })
     } catch (error) {
       console.error('댓글 삭제 실패:', error)
-      alert('댓글 삭제 중 오류가 발생했습니다.')
+      showSnackbar({
+        text: '댓글 삭제 중 오류가 발생했습니다',
+        type: 'error'
+      })
     }
   }
 

--- a/src/pages/detail/DetailAccountItemPage.tsx
+++ b/src/pages/detail/DetailAccountItemPage.tsx
@@ -18,7 +18,7 @@ import { updateComment } from '@/features/detail/service/updateComment'
 import Header from '@/shared/components/header/Header'
 import dayjs from 'dayjs'
 import { Fragment, useEffect, useRef, useState } from 'react'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 
 function DetailAccountItemPage() {
   const { id } = useParams()
@@ -31,6 +31,7 @@ function DetailAccountItemPage() {
   const itemId = detailItemData?.[0]?.id
   const itemCreatedAt = detailItemData?.[0]?.date
   const title = itemCreatedAt ? dayjs(itemCreatedAt).format('M월 D일 ddd') : ''
+  const navigate = useNavigate()
 
   const onOpenArticleToggle = () => {
     setIsArticleToggleOn(!isArticleToggleOn)
@@ -112,13 +113,27 @@ function DetailAccountItemPage() {
     const commentsData = await getCommentsData(id)
     setCommentsData(commentsData)
   }
+
   const fetchDetailData = async (id: string) => {
-    const detailData = await getDetailItemData(id)
-    setDetailItemData(detailData)
+    try {
+      const detailData = await getDetailItemData(id)
+      if (!detailData || detailData.length === 0) {
+        navigate('/404', { replace: true })
+        return
+      }
+      setDetailItemData(detailData)
+    } catch (error) {
+      console.error('게시물 데이터 로드 실패', error)
+      navigate('/404', { replace: true })
+    }
   }
 
   useEffect(() => {
-    if (!id) return
+    if (!id) {
+      navigate('/404', { replace: true })
+      return
+    }
+
     fetchDetailData(id)
     fetchCommentData(id)
   }, [])

--- a/src/pages/detail/DetailAccountItemPage.tsx
+++ b/src/pages/detail/DetailAccountItemPage.tsx
@@ -108,6 +108,10 @@ function DetailAccountItemPage() {
       }
       await updateComment(request!)
       fetchCommentData(id!)
+      showSnackbar({
+        text: '댓글 수정 완료',
+        type: 'success'
+      })
     } catch (error) {
       console.error('댓글 수정 에러', error)
 

--- a/src/shared/components/modal/ConfirmModal.tsx
+++ b/src/shared/components/modal/ConfirmModal.tsx
@@ -23,14 +23,18 @@ function ConfirmModal({
   cancelText = '취소',
   imageSrc
 }: Props) {
-  // Enter 확인
   useEffect(() => {
     const handleEnter = (e: KeyboardEvent) => {
-      if (e.key === 'Enter') onConfirm()
+      if (!open) return
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        e.stopPropagation()
+        onConfirm()
+      }
     }
     window.addEventListener('keydown', handleEnter)
     return () => window.removeEventListener('keydown', handleEnter)
-  }, [onConfirm])
+  }, [open, onConfirm])
 
   return (
     <BaseModal

--- a/src/shared/utils/throttle.ts
+++ b/src/shared/utils/throttle.ts
@@ -1,0 +1,13 @@
+export function throttle<F extends (...args: any[]) => void>(
+  func: F,
+  delay: number
+) {
+  let lastCall = 0
+  return function (...args: Parameters<F>) {
+    const now = Date.now()
+    if (now - lastCall >= delay) {
+      lastCall = now
+      func(...args)
+    }
+  }
+}

--- a/src/shared/utils/throttle.ts
+++ b/src/shared/utils/throttle.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function throttle<F extends (...args: any[]) => void>(
   func: F,
   delay: number


### PR DESCRIPTION
## 🛰️ Issue Number

> ex) #이슈번호, #이슈번호
close #81 

## 🪐 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 📚 Reference

## ✅ Check List
- [x] 댓글 작성 시, 엔터이벤트 중복으로 게시글 삭제되는 버그 해결
- [x] 댓글 - 수정,삭제 1개만 가능
- [x] alert 대신 스낵바로 대체 
- [x] 수정,삭제 메뉴가 아닌곳 클릭해도 닫혀야함
- [x] 리액션 - 색상이랑 데이터 동시에 변화 
- [x] 리액션 안한 경우,getUserReaction()에서 undefined 반환하는 버그 해결
- [x] 다른 사람이 작성한 아이템에는 수정/삭제 안 뜨게 변경
- [x] 상단 날짜를 path의 :date가 아니라 account_items 테이블의 date 컬럼을 보여주도록 수정 -> 라우터 path도 수정
- [x] url 없는 경우 - 404 페이지로 이동
